### PR TITLE
Add Cards collection and listing page

### DIFF
--- a/src/app/(frontend)/cards/page.tsx
+++ b/src/app/(frontend)/cards/page.tsx
@@ -1,0 +1,42 @@
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+import React from 'react'
+
+export const revalidate = 600
+
+export default async function CardsPage() {
+  const payload = await getPayload({ config: configPromise })
+
+  const cards = await payload.find({
+    collection: 'cards',
+    depth: 0,
+    limit: 50,
+  })
+
+  return (
+    <div className="pt-24 pb-24 container">
+      <h1 className="mb-6">Cards</h1>
+      <table className="min-w-full border border-border text-sm">
+        <thead>
+          <tr className="bg-muted">
+            <th className="p-2 border">ID</th>
+            <th className="p-2 border">Name</th>
+            <th className="p-2 border">Words</th>
+            <th className="p-2 border">Category</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cards.docs.map((card) => (
+            <tr key={card.id}>
+              <td className="p-2 border">{card.id}</td>
+              <td className="p-2 border">{card.name}</td>
+              <td className="p-2 border">{Array.isArray(card.words) ? card.words.map((w: any) => (typeof w === 'string' ? w : w.word)).join(', ') : ''}</td>
+              <td className="p-2 border">{card.category}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+

--- a/src/collections/Cards.ts
+++ b/src/collections/Cards.ts
@@ -1,0 +1,41 @@
+import type { CollectionConfig } from 'payload'
+import { authenticated } from '../access/authenticated'
+
+export const Cards: CollectionConfig = {
+  slug: 'cards',
+  access: {
+    create: authenticated,
+    read: authenticated,
+    update: authenticated,
+    delete: authenticated,
+  },
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'id',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'words',
+      type: 'array',
+      fields: [
+        {
+          name: 'word',
+          type: 'text',
+        },
+      ],
+    },
+    {
+      name: 'category',
+      type: 'text',
+    },
+  ],
+}

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,6 +7,7 @@ import { buildConfig, PayloadRequest } from 'payload'
 import { fileURLToPath } from 'url'
 
 import { Categories } from './collections/Categories'
+import { Cards } from './collections/Cards'
 import { Media } from './collections/Media'
 import { Pages } from './collections/Pages'
 import { Posts } from './collections/Posts'
@@ -62,7 +63,7 @@ export default buildConfig({
   db: mongooseAdapter({
     url: process.env.DATABASE_URI || '',
   }),
-  collections: [Pages, Posts, Media, Categories, Users],
+  collections: [Pages, Posts, Media, Categories, Users, Cards],
   cors: [getServerSideURL()].filter(Boolean),
   globals: [Header, Footer],
   plugins: [


### PR DESCRIPTION
## Summary
- create a `Cards` collection with id, name, words and category
- register the collection in `payload.config.ts`
- add a simple listing page under `/cards` to display all cards

## Testing
- `pnpm install` *(fails: forbidden to fetch packages)*
- `pnpm lint` *(fails: cross-env not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_6866ac54851483238eb20a93c2f4efb2