### PR TITLE
Add Cards API and listing page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ DATABASE_URI=mongodb://127.0.0.1/your-database-name
 # Used to encrypt JWT tokens
 PAYLOAD_SECRET=YOUR_SECRET_HERE
 
+# Connection string for Taboo database containing the Cards collection
+TABOO_DATABASE_URI=mongodb://127.0.0.1/Taboo
+
 # Used to configure CORS, format links and more. No trailing slash
 NEXT_PUBLIC_SERVER_URL=http://localhost:3000
 

--- a/src/app/(frontend)/cards/page.client.tsx
+++ b/src/app/(frontend)/cards/page.client.tsx
@@ -1,0 +1,153 @@
+'use client'
+import React, { useState } from 'react'
+
+type Card = {
+  _id?: string
+  id: string
+  name: string
+  Words: string[]
+  category: string
+}
+
+export default function CardsTableClient({ cards: initialCards }: { cards: Card[] }) {
+  const [cards, setCards] = useState<Card[]>(initialCards)
+  const [form, setForm] = useState<Card>({ id: '', name: '', Words: [], category: '' })
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editForm, setEditForm] = useState<Card | null>(null)
+
+  const handleFormChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setForm({ ...form, [name]: value })
+  }
+
+  const createCard = async () => {
+    const res = await fetch('/api/cards', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: form.id,
+        name: form.name,
+        Words: Array.isArray(form.Words) ? form.Words : String(form.Words).split(',').map(w => w.trim()).filter(Boolean),
+        category: form.category,
+      }),
+    })
+    if (res.ok) {
+      const newCard = await res.json()
+      setCards([...cards, newCard])
+      setForm({ id: '', name: '', Words: [], category: '' })
+    }
+  }
+
+  const startEdit = (card: Card) => {
+    setEditingId(card._id || null)
+    setEditForm({ ...card })
+  }
+
+  const handleEditChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!editForm) return
+    const { name, value } = e.target
+    setEditForm({ ...editForm, [name]: value })
+  }
+
+  const saveEdit = async (id: string) => {
+    if (!editForm) return
+    const res = await fetch(`/api/cards/${id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: editForm.id,
+        name: editForm.name,
+        Words: Array.isArray(editForm.Words) ? editForm.Words : String(editForm.Words).split(',').map(w => w.trim()).filter(Boolean),
+        category: editForm.category,
+      }),
+    })
+    if (res.ok) {
+      const updated = await res.json()
+      setCards(cards.map(c => (c._id === id ? updated : c)))
+      setEditingId(null)
+      setEditForm(null)
+    }
+  }
+
+  const deleteCard = async (id: string) => {
+    const res = await fetch(`/api/cards/${id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setCards(cards.filter(c => c._id !== id))
+    }
+  }
+
+  return (
+    <div>
+      <table className="min-w-full border border-border text-sm mb-4">
+        <thead>
+          <tr className="bg-muted">
+            <th className="p-2 border">ID</th>
+            <th className="p-2 border">Name</th>
+            <th className="p-2 border">Words</th>
+            <th className="p-2 border">Category</th>
+            <th className="p-2 border">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cards.map((card) => (
+            <tr key={card._id}>
+              {editingId === card._id ? (
+                <>
+                  <td className="p-2 border">
+                    <input name="id" value={editForm?.id || ''} onChange={handleEditChange} className="border p-1" />
+                  </td>
+                  <td className="p-2 border">
+                    <input name="name" value={editForm?.name || ''} onChange={handleEditChange} className="border p-1" />
+                  </td>
+                  <td className="p-2 border">
+                    <input
+                      name="Words"
+                      value={Array.isArray(editForm?.Words) ? editForm?.Words.join(', ') : ''}
+                      onChange={(e) => setEditForm({ ...(editForm as Card), Words: e.target.value.split(',').map(w => w.trim()) })}
+                      className="border p-1"
+                    />
+                  </td>
+                  <td className="p-2 border">
+                    <input name="category" value={editForm?.category || ''} onChange={handleEditChange} className="border p-1" />
+                  </td>
+                  <td className="p-2 border">
+                    <button className="mr-2 underline" onClick={() => saveEdit(card._id!)}>Save</button>
+                    <button className="underline" onClick={() => { setEditingId(null); setEditForm(null) }}>Cancel</button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td className="p-2 border">{card.id}</td>
+                  <td className="p-2 border">{card.name}</td>
+                  <td className="p-2 border">{card.Words?.join(', ')}</td>
+                  <td className="p-2 border">{card.category}</td>
+                  <td className="p-2 border">
+                    <button className="mr-2 underline" onClick={() => startEdit(card)}>Edit</button>
+                    <button className="underline" onClick={() => deleteCard(card._id!)}>Delete</button>
+                  </td>
+                </>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div className="mb-4">
+        <h2 className="mb-2">Add Card</h2>
+        <div className="flex gap-2 flex-wrap">
+          <input name="id" placeholder="ID" value={form.id} onChange={handleFormChange} className="border p-1" />
+          <input name="name" placeholder="Name" value={form.name} onChange={handleFormChange} className="border p-1" />
+          <input
+            name="Words"
+            placeholder="Words comma separated"
+            value={Array.isArray(form.Words) ? form.Words.join(', ') : ''}
+            onChange={(e) => setForm({ ...form, Words: e.target.value.split(',').map(w => w.trim()) })}
+            className="border p-1"
+          />
+          <input name="category" placeholder="Category" value={form.category} onChange={handleFormChange} className="border p-1" />
+          <button className="px-2 border" onClick={createCard}>Add</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(frontend)/cards/page.tsx
+++ b/src/app/(frontend)/cards/page.tsx
@@ -1,0 +1,17 @@
+import { getServerSideURL } from '@/utilities/getURL'
+import CardsTableClient from './page.client'
+import React from 'react'
+
+export const dynamic = 'force-dynamic'
+
+export default async function CardsPage() {
+  const res = await fetch(`${getServerSideURL()}/api/cards`, { cache: 'no-store' })
+  const cards = await res.json()
+
+  return (
+    <div className="pt-24 pb-24 container">
+      <h1 className="mb-6">Cards</h1>
+      <CardsTableClient cards={cards} />
+    </div>
+  )
+}

--- a/src/app/api/cards/[id]/route.ts
+++ b/src/app/api/cards/[id]/route.ts
@@ -1,0 +1,24 @@
+import { getCardsCollection } from '@/utilities/tabooDB'
+import { ObjectId } from 'mongodb'
+import type { NextRequest } from 'next/server'
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  const collection = await getCardsCollection()
+  const card = await collection.findOne({ _id: new ObjectId(params.id) })
+  if (!card) return new Response('Not found', { status: 404 })
+  return Response.json(card)
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  const data = await req.json()
+  const collection = await getCardsCollection()
+  await collection.updateOne({ _id: new ObjectId(params.id) }, { $set: data })
+  const updated = await collection.findOne({ _id: new ObjectId(params.id) })
+  return Response.json(updated)
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  const collection = await getCardsCollection()
+  await collection.deleteOne({ _id: new ObjectId(params.id) })
+  return new Response(null, { status: 204 })
+}

--- a/src/app/api/cards/route.ts
+++ b/src/app/api/cards/route.ts
@@ -1,0 +1,16 @@
+import { getCardsCollection } from '@/utilities/tabooDB'
+import type { NextRequest } from 'next/server'
+
+export async function GET() {
+  const collection = await getCardsCollection()
+  const cards = await collection.find({}).toArray()
+  return Response.json(cards)
+}
+
+export async function POST(req: NextRequest) {
+  const data = await req.json()
+  const collection = await getCardsCollection()
+  const result = await collection.insertOne(data)
+  const inserted = await collection.findOne({ _id: result.insertedId })
+  return Response.json(inserted, { status: 201 })
+}

--- a/src/collections/Cards.ts
+++ b/src/collections/Cards.ts
@@ -1,0 +1,38 @@
+import type { CollectionConfig } from 'payload'
+import { authenticated } from '../access/authenticated'
+
+export const Cards: CollectionConfig = {
+  slug: 'cards',
+  access: {
+    create: authenticated,
+    read: authenticated,
+    update: authenticated,
+    delete: authenticated,
+  },
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'id',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      // Stored as `Words` in the existing database
+      name: 'Words',
+      label: 'Words',
+      type: 'text',
+      hasMany: true,
+    },
+    {
+      name: 'category',
+      type: 'text',
+    },
+  ],
+}

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -3,6 +3,7 @@ declare global {
     interface ProcessEnv {
       PAYLOAD_SECRET: string
       DATABASE_URI: string
+      TABOO_DATABASE_URI: string
       NEXT_PUBLIC_SERVER_URL: string
       VERCEL_PROJECT_PRODUCTION_URL: string
     }

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -7,6 +7,7 @@ import { buildConfig, PayloadRequest } from 'payload'
 import { fileURLToPath } from 'url'
 
 import { Categories } from './collections/Categories'
+import { Cards } from './collections/Cards'
 import { Media } from './collections/Media'
 import { Pages } from './collections/Pages'
 import { Posts } from './collections/Posts'
@@ -62,7 +63,7 @@ export default buildConfig({
   db: mongooseAdapter({
     url: process.env.DATABASE_URI || '',
   }),
-  collections: [Pages, Posts, Media, Categories, Users],
+  collections: [Pages, Posts, Media, Categories, Users, Cards],
   cors: [getServerSideURL()].filter(Boolean),
   globals: [Header, Footer],
   plugins: [

--- a/src/utilities/tabooDB.ts
+++ b/src/utilities/tabooDB.ts
@@ -1,0 +1,12 @@
+import { MongoClient, Collection } from 'mongodb'
+
+let clientPromise: Promise<MongoClient> | null = null
+
+export async function getCardsCollection(): Promise<Collection> {
+  if (!clientPromise) {
+    const uri = process.env.TABOO_DATABASE_URI || ''
+    clientPromise = MongoClient.connect(uri)
+  }
+  const client = await clientPromise
+  return client.db('Taboo').collection('Cards')
+}


### PR DESCRIPTION
## Summary
- add `TABOO_DATABASE_URI` env variable for the Taboo DB
- create a Mongo helper to connect to `Taboo.Cards`
- expose CRUD API routes under `/api/cards`
- add interactive table with create, update, delete actions
- fetch cards via API on the `/cards` page
- fix Cards collection schema to match existing database (use `Words` array)

## Testing
- `pnpm lint` *(fails: cross-env not found)*
- `pnpm test` *(no output)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6866ac54851483238eb20a93c2f4efb2